### PR TITLE
Update site identity and article licensing

### DIFF
--- a/website/public/favicon.svg
+++ b/website/public/favicon.svg
@@ -1,4 +1,22 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" rx="8" fill="#1746a2"/>
-  <path fill="#f6f2e9" d="M17 14h16.2c8.2 0 13.1 3.8 13.1 10.1 0 4.2-2.3 7.3-6.2 8.7 5 1.1 7.9 4.6 7.9 9.2C48 49.2 42.6 53 33.6 53H17V14Zm15 15.8c4.3 0 6.7-1.8 6.7-5s-2.4-4.8-6.7-4.8h-7.2v9.8H32Zm1 17.2c4.6 0 7.2-2 7.2-5.6s-2.6-5.5-7.2-5.5h-8.2V47H33Z"/>
+  <style>
+    .background { fill: #181817; }
+    .initials { fill: #e9e9e5; }
+
+    @media (prefers-color-scheme: dark) {
+      .background { fill: #e5e5df; }
+      .initials { fill: #171817; }
+    }
+  </style>
+  <rect class="background" width="64" height="64" rx="8"/>
+  <text
+    class="initials"
+    x="32"
+    y="41"
+    font-family="Helvetica, Arial, sans-serif"
+    font-size="27"
+    font-weight="700"
+    letter-spacing="0.5"
+    text-anchor="middle"
+  >BK</text>
 </svg>

--- a/website/src/components/SiteFooter.astro
+++ b/website/src/components/SiteFooter.astro
@@ -4,7 +4,13 @@ const year = new Date().getUTCFullYear();
 
 <footer class="site-footer">
   <div class="site-shell site-footer__inner">
-    <p class="footer-id">Boris Kayi / {year}</p>
+    <div class="footer-copy">
+      <p class="footer-id">Boris Kayiranga / {year}</p>
+      <p class="footer-license">
+        All articles are licensed under
+        <a href="https://creativecommons.org/licenses/by-nd/4.0/" rel="license">CC BY-ND 4.0</a>.
+      </p>
+    </div>
     <nav aria-label="Elsewhere">
       <a href="https://github.com/silverhairs" rel="me">GitHub</a>
       <a href="/rss.xml">RSS</a>

--- a/website/src/components/SiteHeader.astro
+++ b/website/src/components/SiteHeader.astro
@@ -5,7 +5,7 @@ const writingIsCurrent = path.startsWith("/writing");
 
 <header class="site-header">
   <div class="site-shell site-header__inner">
-    <a class="site-name" href="/" aria-label="Boris Kayi, home">Boris Kayi</a>
+    <a class="site-name" href="/" aria-label="Boris Kayiranga, home">Boris Kayiranga</a>
     <nav aria-label="Primary navigation">
       <a href="/" aria-current={path === "/" ? "page" : undefined}><span>00</span> Home</a>
       <a href="/writing/" aria-current={writingIsCurrent ? "page" : undefined}><span>01</span> Writing</a>

--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -11,7 +11,7 @@ interface Props {
 }
 
 const { title, description, type = "website" } = Astro.props;
-const pageTitle = title === "Boris Kayi" ? title : `${title} — Boris Kayi`;
+const pageTitle = title === "Boris Kayiranga" ? title : `${title} — Boris Kayiranga`;
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 ---
 
@@ -25,9 +25,9 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
     <meta name="description" content={description} />
     <link rel="canonical" href={canonicalURL} />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="alternate" type="application/rss+xml" title="Boris Kayi's writing" href="/rss.xml" />
+    <link rel="alternate" type="application/rss+xml" title="Boris Kayiranga's writing" href="/rss.xml" />
     <meta property="og:type" content={type} />
-    <meta property="og:site_name" content="Boris Kayi" />
+    <meta property="og:site_name" content="Boris Kayiranga" />
     <meta property="og:title" content={pageTitle} />
     <meta property="og:description" content={description} />
     <meta property="og:url" content={canonicalURL} />

--- a/website/src/pages/about.astro
+++ b/website/src/pages/about.astro
@@ -5,7 +5,7 @@ import FolioMark from "../components/FolioMark.astro";
 
 <BaseLayout
   title="About"
-  description="About Boris Kayi, a software engineer working on energy hardware integration."
+  description="About Boris Kayiranga, a software engineer working on energy hardware integration."
 >
   <div class="page folio-page">
     <FolioMark number="02" label="About" />
@@ -16,7 +16,7 @@ import FolioMark from "../components/FolioMark.astro";
 
       <article class="prose about-copy">
         <p>
-          I’m Boris Kayi, a software engineer with experience building products and developer tools. I
+          I’m Boris Kayiranga, a software engineer with experience building products and developer tools. I
           currently work at <a href="https://enpal.com">Enpal</a> as a Senior Software Engineer, focused on
           energy hardware integration.
         </p>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -8,14 +8,14 @@ const articles = (await getArticles()).slice(0, 5);
 ---
 
 <BaseLayout
-  title="Boris Kayi"
-  description="Boris Kayi writes about software, books, energy, urbanism, and things noticed along the way."
+  title="Boris Kayiranga"
+  description="Boris Kayiranga writes about software, books, energy, urbanism, and things noticed along the way."
 >
   <div class="page folio-page home-page">
     <FolioMark number="00" label="Index" />
     <div class="folio-body">
       <section class="home-intro" aria-labelledby="home-heading">
-        <h1 id="home-heading">Boris Kayi</h1>
+        <h1 id="home-heading">Boris Kayiranga</h1>
         <p>
           I’m a software engineer at <a href="https://enpal.com">Enpal</a>, working on energy hardware
           integration. I also read, build toy compilers, and follow whatever has my attention.

--- a/website/src/pages/rss.xml.ts
+++ b/website/src/pages/rss.xml.ts
@@ -6,7 +6,7 @@ export async function GET(context: APIContext) {
   const articles = await getArticles({ includeDrafts: false });
 
   return rss({
-    title: "Boris Kayi’s writing",
+    title: "Boris Kayiranga’s writing",
     description: "Essays and notes about books, software, energy, urbanism, and everyday observations.",
     site: context.site ?? "https://silverhairs.dev",
     items: articles.map((article) => ({

--- a/website/src/pages/writing/index.astro
+++ b/website/src/pages/writing/index.astro
@@ -9,7 +9,7 @@ const articles = await getArticles();
 
 <BaseLayout
   title="Writing"
-  description="Essays and notes by Boris Kayi about books, software, energy, urbanism, and everyday observations."
+  description="Essays and notes by Boris Kayiranga about books, software, energy, urbanism, and everyday observations."
 >
   <div class="page folio-page">
     <FolioMark number="01" label="Writing" />

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -711,8 +711,17 @@ h4 {
   margin: 0;
 }
 
+.footer-copy {
+  display: grid;
+  gap: 0.2rem;
+}
+
 .footer-id {
   color: var(--muted);
+}
+
+.footer-license a {
+  color: inherit;
 }
 
 .site-footer nav {


### PR DESCRIPTION
## Summary

- update the site identity to Boris Kayiranga across visible copy and metadata
- replace the blue favicon with a monochrome BK mark
- add a CC BY-ND 4.0 article license notice to the footer

## Verification

- npm run build