### PR TITLE
Enable Cloudflare Workers observability

### DIFF
--- a/website/wrangler.jsonc
+++ b/website/wrangler.jsonc
@@ -6,5 +6,9 @@
     "directory": "./dist",
     "html_handling": "auto-trailing-slash",
     "not_found_handling": "404-page"
+  },
+  "observability": {
+    "enabled": true,
+    "head_sampling_rate": 1
   }
 }


### PR DESCRIPTION
## Summary

- enable Cloudflare Workers observability in Wrangler
- retain every invocation with a head sampling rate of 1

## Verification

- npm run build
- npx wrangler deploy --dry-run